### PR TITLE
Feature/assertion template param

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpmd/phpmd": "^2.0",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-strict-rules": "^1.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^9.3",
         "psalm/plugin-phpunit": "^0.18",
         "vimeo/psalm": "^5.0"
     },

--- a/src/Assertion/Assertion.php
+++ b/src/Assertion/Assertion.php
@@ -16,12 +16,12 @@ use Vivarium\Assertion\Exception\AssertionFailed;
 interface Assertion
 {
     /**
-     * @param T $value
-     *
      * @throws AssertionFailed
+     *
+     * @psalm-assert T $value
      */
-    public function assert($value, string $message = ''): void;
+    public function assert(mixed $value, string $message = ''): void;
 
-    /** @param T $value */
-    public function __invoke($value): bool;
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool;
 }

--- a/src/Assertion/Boolean/IsFalse.php
+++ b/src/Assertion/Boolean/IsFalse.php
@@ -18,15 +18,11 @@ use Vivarium\Assertion\Type\IsBoolean;
 
 use function sprintf;
 
-/** @template-implements Assertion<bool> */
+/** @template-implements Assertion<false> */
 final class IsFalse implements Assertion
 {
-    /**
-     * @param bool $value
-     *
-     * @psalm-assert false $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert false $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -39,12 +35,8 @@ final class IsFalse implements Assertion
         }
     }
 
-    /**
-     * @param bool $value
-     *
-     * @psalm-assert-if-true false $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true false $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsBoolean())->assert($value);
 

--- a/src/Assertion/Boolean/IsTrue.php
+++ b/src/Assertion/Boolean/IsTrue.php
@@ -18,15 +18,11 @@ use Vivarium\Assertion\Type\IsBoolean;
 
 use function sprintf;
 
-/** @template-implements Assertion<bool> */
+/** @template-implements Assertion<true> */
 final class IsTrue implements Assertion
 {
-    /**
-     * @param bool $value
-     *
-     * @psalm-assert true $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert true $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -39,12 +35,8 @@ final class IsTrue implements Assertion
         }
     }
 
-    /**
-     * @param bool $value
-     *
-     * @psalm-assert-if-true true $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true true $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsBoolean())->assert($value);
 

--- a/src/Assertion/Comparison/IsEqualsTo.php
+++ b/src/Assertion/Comparison/IsEqualsTo.php
@@ -29,12 +29,8 @@ final class IsEqualsTo implements Assertion
     {
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert =T $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -48,12 +44,8 @@ final class IsEqualsTo implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true =T $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         return (new EqualsBuilder())
             ->append($value, $this->compare)

--- a/src/Assertion/Comparison/IsOneOf.php
+++ b/src/Assertion/Comparison/IsOneOf.php
@@ -38,12 +38,8 @@ final class IsOneOf implements Assertion
         $this->choices = array_merge([$choice], $choices);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert T $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -56,12 +52,8 @@ final class IsOneOf implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true T $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         foreach ($this->choices as $choice) {
             if ((new EqualsBuilder())->append($value, $choice)->isEquals()) {

--- a/src/Assertion/Comparison/IsSameOf.php
+++ b/src/Assertion/Comparison/IsSameOf.php
@@ -29,12 +29,8 @@ final class IsSameOf implements Assertion
     {
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert =T $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -48,12 +44,8 @@ final class IsSameOf implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true =T $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         return $value === $this->compare;
     }

--- a/src/Assertion/Conditional/All.php
+++ b/src/Assertion/Conditional/All.php
@@ -33,16 +33,16 @@ final class All implements Assertion
         $this->assertions = array_merge([$assertion], $assertions);
     }
 
-    /** @param T $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         foreach ($this->assertions as $assertion) {
             $assertion->assert($value, $message);
         }
     }
 
-    /** @param T $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         try {
             $this->assert($value);

--- a/src/Assertion/Conditional/Each.php
+++ b/src/Assertion/Conditional/Each.php
@@ -24,15 +24,9 @@ use function sprintf;
  */
 final class Each implements Assertion
 {
-    /** @var Assertion<T> */
-    private Assertion $assertion;
-
-    /**
-     * @param Assertion<T> $assertion
-     */
-    public function __construct(Assertion $assertion)
+    /** @param Assertion<T> $assertion */
+    public function __construct(private Assertion $assertion)
     {
-        $this->assertion = $assertion;
     }
 
     /** @psalm-assert array<T> $value */

--- a/src/Assertion/Conditional/Either.php
+++ b/src/Assertion/Conditional/Either.php
@@ -30,8 +30,9 @@ final class Either implements Assertion
      */
     public function __construct(
         private Assertion $assertion1,
-        private Assertion $assertion2
-    ) {}
+        private Assertion $assertion2,
+    ) {
+    }
 
     /** @psalm-assert A|B $value */
     public function assert(mixed $value, string $message = ''): void

--- a/src/Assertion/Conditional/Either.php
+++ b/src/Assertion/Conditional/Either.php
@@ -15,29 +15,26 @@ use Vivarium\Assertion\Exception\AssertionFailed;
 use Vivarium\Assertion\Helpers\TypeToString;
 use Vivarium\Assertion\String\IsEmpty;
 
-use function array_merge;
 use function sprintf;
 
 /**
- * @template T
- * @template-implements Assertion<T>
+ * @template A
+ * @template B
+ * @template-implements Assertion<A|B>
  */
 final class Either implements Assertion
 {
-    /** @var array<Assertion<T>> */
-    private array $assertions;
-
     /**
-     * @param Assertion<T> $assertion
-     * @param Assertion<T> ...$assertions
+     * @param Assertion<A> $assertion1
+     * @param Assertion<B> $assertion2
      */
-    public function __construct(Assertion $assertion, Assertion ...$assertions)
-    {
-        $this->assertions = array_merge([$assertion], $assertions);
-    }
+    public function __construct(
+        private Assertion $assertion1,
+        private Assertion $assertion2
+    ) {}
 
-    /** @param T $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert A|B $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -50,15 +47,9 @@ final class Either implements Assertion
         }
     }
 
-    /** @param T $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true A|B $value */
+    public function __invoke(mixed $value): bool
     {
-        foreach ($this->assertions as $assertion) {
-            if ($assertion($value)) {
-                return true;
-            }
-        }
-
-        return false;
+        return ($this->assertion1)($value) || ($this->assertion2)($value);
     }
 }

--- a/src/Assertion/Conditional/Not.php
+++ b/src/Assertion/Conditional/Not.php
@@ -29,8 +29,8 @@ final class Not implements Assertion
     {
     }
 
-    /** @param T $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert !T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -44,8 +44,8 @@ final class Not implements Assertion
         }
     }
 
-    /** @param T $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true !T $value */
+    public function __invoke(mixed $value): bool
     {
         return ! ($this->assertion)($value);
     }

--- a/src/Assertion/Conditional/NullOr.php
+++ b/src/Assertion/Conditional/NullOr.php
@@ -14,24 +14,18 @@ use InvalidArgumentException;
 use Vivarium\Assertion\Assertion;
 
 /**
- * @template K
- * @template-implements Assertion<mixed>
+ * @template T
+ * @template-implements Assertion<T|null>
  */
 final class NullOr implements Assertion
 {
-    /** @param Assertion<K> $assertion */
+    /** @param Assertion<T> $assertion */
     public function __construct(private Assertion $assertion)
     {
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @throws InvalidArgumentException
-     *
-     * @psalm-assert K|null $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T|null $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if ($value === null) {
             return;
@@ -40,12 +34,8 @@ final class NullOr implements Assertion
         $this->assertion->assert($value, $message);
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true K|null $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T|null $value */
+    public function __invoke(mixed $value): bool
     {
         return $value === null || ($this->assertion)($value);
     }

--- a/src/Assertion/Conditional/NullOr.php
+++ b/src/Assertion/Conditional/NullOr.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Vivarium\Assertion\Conditional;
 
-use InvalidArgumentException;
 use Vivarium\Assertion\Assertion;
 
 /**

--- a/src/Assertion/Encoding/IsEncoding.php
+++ b/src/Assertion/Encoding/IsEncoding.php
@@ -34,7 +34,7 @@ final class IsEncoding implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/Encoding/IsEncoding.php
+++ b/src/Assertion/Encoding/IsEncoding.php
@@ -21,8 +21,8 @@ use function sprintf;
 /** @template-implements Assertion<string> */
 final class IsEncoding implements Assertion
 {
-    /** @param string $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! ($this)($value)) {
             $message = sprintf(
@@ -34,8 +34,8 @@ final class IsEncoding implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/Encoding/IsRegexEncoding.php
+++ b/src/Assertion/Encoding/IsRegexEncoding.php
@@ -36,7 +36,10 @@ final class IsRegexEncoding implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /**
+     * @psalm-assert string $value
+     * @SuppressWarnings(PHPMD.ErrorControlOperator)
+     */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/Encoding/IsRegexEncoding.php
+++ b/src/Assertion/Encoding/IsRegexEncoding.php
@@ -23,8 +23,8 @@ use function sprintf;
 /** @template-implements Assertion<string> */
 final class IsRegexEncoding implements Assertion
 {
-    /** @param string $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! ($this)($value)) {
             $message = sprintf(
@@ -36,13 +36,8 @@ final class IsRegexEncoding implements Assertion
         }
     }
 
-    /**
-     * @param string $value
-     *
-     * @psalm-suppress ImpureFunctionCall  mb_regex_encoding is called and then restored
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 
@@ -55,7 +50,6 @@ final class IsRegexEncoding implements Assertion
         } catch (ValueError) {
             $valid = false;
         } finally {
-            /** @psalm-suppress UnusedFunctionCall We can ignore the result since we are restoring the previous value */
             mb_regex_encoding($encoding);
         }
 

--- a/src/Assertion/Encoding/IsSystemEncoding.php
+++ b/src/Assertion/Encoding/IsSystemEncoding.php
@@ -36,7 +36,10 @@ final class IsSystemEncoding implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /**
+     * @psalm-assert string $value
+     * @SuppressWarnings(PHPMD.ErrorControlOperator)
+     */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/Encoding/IsSystemEncoding.php
+++ b/src/Assertion/Encoding/IsSystemEncoding.php
@@ -23,8 +23,8 @@ use function sprintf;
 /** @template-implements Assertion<string> */
 final class IsSystemEncoding implements Assertion
 {
-    /** @param string $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! ($this)($value)) {
             $message = sprintf(
@@ -36,13 +36,8 @@ final class IsSystemEncoding implements Assertion
         }
     }
 
-    /**
-     * @param string $value
-     *
-     * @psalm-suppress ImpureFunctionCall  mb_internal_encoding is called and then restored
-     * @SuppressWarnings(PHPMD.ErrorControlOperator)
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/Helpers/TypeToString.php
+++ b/src/Assertion/Helpers/TypeToString.php
@@ -17,8 +17,7 @@ use function is_string;
 /** @internal */
 final class TypeToString
 {
-    /** @param mixed $value */
-    public function __invoke($value): string
+    public function __invoke(mixed $value): string
     {
         if ($value === true) {
             return 'true';

--- a/src/Assertion/Hierarchy/ImplementsInterface.php
+++ b/src/Assertion/Hierarchy/ImplementsInterface.php
@@ -23,7 +23,7 @@ use function sprintf;
 
 /**
  * @template T
- * @template-implements Assertion<class-string>
+ * @template-implements Assertion<class-string<T>>
  */
 final class ImplementsInterface implements Assertion
 {
@@ -33,12 +33,7 @@ final class ImplementsInterface implements Assertion
         (new IsInterface())->assert($interface);
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert class-string<T> $value
-     */
-    public function assert($value, string $message = ''): void
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -52,18 +47,12 @@ final class ImplementsInterface implements Assertion
         }
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert-if-true class-string<T> $value
-     */
-    public function __invoke($value): bool
+    public function __invoke(mixed $value): bool
     {
         (new IsClass())->assert($value);
 
         $interfaces = class_implements($value);
 
-        return $interfaces === false ?
-            $interfaces : in_array($this->interface, $interfaces, true);
+        return $interfaces !== false && in_array($this->interface, $interfaces, true);
     }
 }

--- a/src/Assertion/Hierarchy/ImplementsInterface.php
+++ b/src/Assertion/Hierarchy/ImplementsInterface.php
@@ -33,6 +33,7 @@ final class ImplementsInterface implements Assertion
         (new IsInterface())->assert($interface);
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
@@ -47,6 +48,7 @@ final class ImplementsInterface implements Assertion
         }
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function __invoke(mixed $value): bool
     {
         (new IsClass())->assert($value);

--- a/src/Assertion/Hierarchy/IsAssignableTo.php
+++ b/src/Assertion/Hierarchy/IsAssignableTo.php
@@ -21,7 +21,7 @@ use function sprintf;
 
 /**
  * @template T
- * @template-implements Assertion<class-string>
+ * @template-implements Assertion<class-string<T>>
  */
 final class IsAssignableTo implements Assertion
 {
@@ -31,12 +31,7 @@ final class IsAssignableTo implements Assertion
         (new IsClassOrInterface())->assert($class);
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert class-string<T> $value
-     */
-    public function assert($value, string $message = ''): void
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -50,12 +45,7 @@ final class IsAssignableTo implements Assertion
         }
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert-if-true class-string<T> $value
-     */
-    public function __invoke($value): bool
+    public function __invoke(mixed $value): bool
     {
         (new IsClassOrInterface())->assert($value);
 

--- a/src/Assertion/Hierarchy/IsAssignableTo.php
+++ b/src/Assertion/Hierarchy/IsAssignableTo.php
@@ -31,6 +31,7 @@ final class IsAssignableTo implements Assertion
         (new IsClassOrInterface())->assert($class);
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
@@ -45,6 +46,7 @@ final class IsAssignableTo implements Assertion
         }
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function __invoke(mixed $value): bool
     {
         (new IsClassOrInterface())->assert($value);

--- a/src/Assertion/Hierarchy/IsSubclassOf.php
+++ b/src/Assertion/Hierarchy/IsSubclassOf.php
@@ -34,6 +34,7 @@ final class IsSubclassOf implements Assertion
         (new IsClassOrInterface())->assert($class);
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
@@ -48,6 +49,7 @@ final class IsSubclassOf implements Assertion
         }
     }
 
+    /** @psalm-assert class-string<T> $value */
     public function __invoke(mixed $value): bool
     {
         (new Either(

--- a/src/Assertion/Hierarchy/IsSubclassOf.php
+++ b/src/Assertion/Hierarchy/IsSubclassOf.php
@@ -24,7 +24,7 @@ use function sprintf;
 
 /**
  * @template T
- * @template-implements Assertion<class-string>
+ * @template-implements Assertion<class-string<T>>
  */
 final class IsSubclassOf implements Assertion
 {
@@ -34,12 +34,7 @@ final class IsSubclassOf implements Assertion
         (new IsClassOrInterface())->assert($class);
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert class-string<T> $value
-     */
-    public function assert($value, string $message = ''): void
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -53,12 +48,7 @@ final class IsSubclassOf implements Assertion
         }
     }
 
-    /**
-     * @param class-string $value
-     *
-     * @psalm-assert-if-true class-string<T> $value
-     */
-    public function __invoke($value): bool
+    public function __invoke(mixed $value): bool
     {
         (new Either(
             new IsClass(),

--- a/src/Assertion/Numeric/IsGreaterOrEqualThan.php
+++ b/src/Assertion/Numeric/IsGreaterOrEqualThan.php
@@ -11,33 +11,35 @@ declare(strict_types=1);
 namespace Vivarium\Assertion\Numeric;
 
 use Vivarium\Assertion\Assertion;
+use Vivarium\Assertion\Conditional\Either;
 use Vivarium\Assertion\Exception\AssertionFailed;
 use Vivarium\Assertion\Helpers\TypeToString;
 use Vivarium\Assertion\String\IsEmpty;
+use Vivarium\Assertion\Type\IsFloat;
+use Vivarium\Assertion\Type\IsInteger;
 use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T of int|float
+ * @template-implements Assertion<T>
+ */
 final class IsGreaterOrEqualThan implements Assertion
 {
-    private int|float $compare;
+    /** @var T */
+    private $compare;
 
-    /** @param int|float $compare */
+    /** @param T $compare */
     public function __construct($compare)
     {
-        (new IsNumeric())
-            ->assert($compare);
+        (new IsNumeric())->assert($compare);
 
         $this->compare = $compare;
     }
 
-    /**
-     * @param int|float $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -51,8 +53,8 @@ final class IsGreaterOrEqualThan implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsGreaterOrEqualThan.php
+++ b/src/Assertion/Numeric/IsGreaterOrEqualThan.php
@@ -11,12 +11,9 @@ declare(strict_types=1);
 namespace Vivarium\Assertion\Numeric;
 
 use Vivarium\Assertion\Assertion;
-use Vivarium\Assertion\Conditional\Either;
 use Vivarium\Assertion\Exception\AssertionFailed;
 use Vivarium\Assertion\Helpers\TypeToString;
 use Vivarium\Assertion\String\IsEmpty;
-use Vivarium\Assertion\Type\IsFloat;
-use Vivarium\Assertion\Type\IsInteger;
 use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
@@ -27,15 +24,10 @@ use function sprintf;
  */
 final class IsGreaterOrEqualThan implements Assertion
 {
-    /** @var T */
-    private $compare;
-
     /** @param T $compare */
-    public function __construct($compare)
+    public function __construct(private $compare)
     {
         (new IsNumeric())->assert($compare);
-
-        $this->compare = $compare;
     }
 
     /** @psalm-assert T $value */
@@ -53,7 +45,7 @@ final class IsGreaterOrEqualThan implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsGreaterThan.php
+++ b/src/Assertion/Numeric/IsGreaterThan.php
@@ -24,18 +24,10 @@ use function sprintf;
  */
 final class IsGreaterThan implements Assertion
 {
-    /** @var T */
-    private $compare;
-
     /** @param T $compare */
-    public function __construct($compare)
+    public function __construct(private $compare)
     {
         (new IsNumeric())->assert($compare);
-
-        /**
-         * @var T $compare
-         */
-        $this->compare = $compare;
     }
 
     /** @psalm-assert T $value */
@@ -53,7 +45,7 @@ final class IsGreaterThan implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsGreaterThan.php
+++ b/src/Assertion/Numeric/IsGreaterThan.php
@@ -18,19 +18,28 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsGreaterThan implements Assertion
 {
-    private int|float $compare;
+    /** @var T */
+    private $compare;
 
-    /** @param int|float $compare */
+    /** @param T $compare */
     public function __construct($compare)
     {
+        (new IsNumeric())->assert($compare);
+
+        /**
+         * @var T $compare
+         */
         $this->compare = $compare;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -44,8 +53,8 @@ final class IsGreaterThan implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsInClosedRange.php
+++ b/src/Assertion/Numeric/IsInClosedRange.php
@@ -24,23 +24,14 @@ use function sprintf;
  */
 final class IsInClosedRange implements Assertion
 {
-    /** @var T */
-    private $min;
-
-    /** @var T */
-    private $max;
-
     /**
      * @param T $min
      * @param T $max
      */
-    public function __construct($min, $max)
+    public function __construct(private $min, private $max)
     {
         (new IsLessOrEqualThan($max))
             ->assert($min, 'Lower bound must be lower or equal than upper bound. Got [%1$s, %2$s].');
-
-        $this->min = $min;
-        $this->max = $max;
     }
 
     /** @psalm-assert T $value */
@@ -59,7 +50,7 @@ final class IsInClosedRange implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsInClosedRange.php
+++ b/src/Assertion/Numeric/IsInClosedRange.php
@@ -18,16 +18,21 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsInClosedRange implements Assertion
 {
-    private int|float $min;
+    /** @var T */
+    private $min;
 
-    private int|float $max;
+    /** @var T */
+    private $max;
 
     /**
-     * @param int|float $min
-     * @param int|float $max
+     * @param T $min
+     * @param T $max
      */
     public function __construct($min, $max)
     {
@@ -38,8 +43,8 @@ final class IsInClosedRange implements Assertion
         $this->max = $max;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -54,8 +59,8 @@ final class IsInClosedRange implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsInHalfOpenRightRange.php
+++ b/src/Assertion/Numeric/IsInHalfOpenRightRange.php
@@ -18,16 +18,21 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsInHalfOpenRightRange implements Assertion
 {
-    private int|float $min;
+    /** @var T */
+    private $min;
 
-    private int|float $max;
+    /** @var T */
+    private $max;
 
     /**
-     * @param int|float $min
-     * @param int|float $max
+     * @param T $min
+     * @param T $max
      */
     public function __construct($min, $max)
     {
@@ -38,8 +43,8 @@ final class IsInHalfOpenRightRange implements Assertion
         $this->max = $max;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -54,8 +59,8 @@ final class IsInHalfOpenRightRange implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsInHalfOpenRightRange.php
+++ b/src/Assertion/Numeric/IsInHalfOpenRightRange.php
@@ -24,23 +24,14 @@ use function sprintf;
  */
 final class IsInHalfOpenRightRange implements Assertion
 {
-    /** @var T */
-    private $min;
-
-    /** @var T */
-    private $max;
-
     /**
      * @param T $min
      * @param T $max
      */
-    public function __construct($min, $max)
+    public function __construct(private $min, private $max)
     {
         (new IsLessOrEqualThan($max))
             ->assert($min, 'Lower bound must be lower than upper bound. Got [%1$s, %2$s).');
-
-        $this->min = $min;
-        $this->max = $max;
     }
 
     /** @psalm-assert T $value */
@@ -59,7 +50,7 @@ final class IsInHalfOpenRightRange implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsInOpenRange.php
+++ b/src/Assertion/Numeric/IsInOpenRange.php
@@ -18,16 +18,21 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsInOpenRange implements Assertion
 {
-    private int|float $min;
+    /** @var T */
+    private $min;
 
-    private int|float $max;
+    /** @var T */
+    private $max;
 
     /**
-     * @param int|float $min
-     * @param int|float $max
+     * @param T $min
+     * @param T $max
      */
     public function __construct($min, $max)
     {
@@ -38,8 +43,8 @@ final class IsInOpenRange implements Assertion
         $this->max = $max;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -54,10 +59,11 @@ final class IsInOpenRange implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
-        (new IsNumeric())->assert($value);
+        (new IsNumeric())
+            ->assert($value);
 
         return ($this->min < $value) && ($value < $this->max);
     }

--- a/src/Assertion/Numeric/IsInOpenRange.php
+++ b/src/Assertion/Numeric/IsInOpenRange.php
@@ -24,23 +24,14 @@ use function sprintf;
  */
 final class IsInOpenRange implements Assertion
 {
-    /** @var T */
-    private $min;
-
-    /** @var T */
-    private $max;
-
     /**
      * @param T $min
      * @param T $max
      */
-    public function __construct($min, $max)
+    public function __construct(private $min, private $max)
     {
         (new IsLessThan($max))
             ->assert($min, 'Lower bound must be lower than upper bound. Got (%1$s, %2$s).');
-
-        $this->min = $min;
-        $this->max = $max;
     }
 
     /** @psalm-assert T $value */
@@ -59,7 +50,7 @@ final class IsInOpenRange implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())

--- a/src/Assertion/Numeric/IsLessOrEqualThan.php
+++ b/src/Assertion/Numeric/IsLessOrEqualThan.php
@@ -24,18 +24,10 @@ use function sprintf;
  */
 final class IsLessOrEqualThan implements Assertion
 {
-    /** @var T */
-    private $compare;
-
     /** @param T $compare */
-    public function __construct($compare)
+    public function __construct(private $compare)
     {
         (new IsNumeric())->assert($compare);
-
-        /**
-         * @var T $compare
-         */
-        $this->compare = $compare;
     }
 
     /** @psalm-assert T $value */
@@ -53,7 +45,7 @@ final class IsLessOrEqualThan implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsLessOrEqualThan.php
+++ b/src/Assertion/Numeric/IsLessOrEqualThan.php
@@ -18,18 +18,28 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsLessOrEqualThan implements Assertion
 {
-    private int|float $compare;
+    /** @var T */
+    private $compare;
 
-    public function __construct(float $compare)
+    /** @param T $compare */
+    public function __construct($compare)
     {
+        (new IsNumeric())->assert($compare);
+
+        /**
+         * @var T $compare
+         */
         $this->compare = $compare;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,8 +53,8 @@ final class IsLessOrEqualThan implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsLessThan.php
+++ b/src/Assertion/Numeric/IsLessThan.php
@@ -18,19 +18,28 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsLessThan implements Assertion
 {
-    private int|float $compare;
+    /** @var T */
+    private $compare;
 
-    /** @param int|float $compare */
+    /** @param T $compare */
     public function __construct($compare)
     {
+        (new IsNumeric())->assert($compare);
+
+        /**
+         * @var T $compare
+         */
         $this->compare = $compare;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -44,8 +53,8 @@ final class IsLessThan implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Numeric/IsLessThan.php
+++ b/src/Assertion/Numeric/IsLessThan.php
@@ -24,18 +24,10 @@ use function sprintf;
  */
 final class IsLessThan implements Assertion
 {
-    /** @var T */
-    private $compare;
-
     /** @param T $compare */
-    public function __construct($compare)
+    public function __construct(private $compare)
     {
         (new IsNumeric())->assert($compare);
-
-        /**
-         * @var T $compare
-         */
-        $this->compare = $compare;
     }
 
     /** @psalm-assert T $value */
@@ -53,7 +45,7 @@ final class IsLessThan implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsOutOfClosedRange.php
+++ b/src/Assertion/Numeric/IsOutOfClosedRange.php
@@ -24,23 +24,14 @@ use function sprintf;
  */
 final class IsOutOfClosedRange implements Assertion
 {
-    /** @var T */
-    private $min;
-
-    /** @var T */
-    private $max;
-
     /**
      * @param T $min
      * @param T $max
      */
-    public function __construct($min, $max)
+    public function __construct(private $min, private $max)
     {
         (new IsLessThan($max))
             ->assert($min, 'Lower bound must be lower than upper bound. Got [%1$s, %2$s].');
-
-        $this->min = $min;
-        $this->max = $max;
     }
 
     /** @psalm-assert T $value */
@@ -59,7 +50,7 @@ final class IsOutOfClosedRange implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())

--- a/src/Assertion/Numeric/IsOutOfClosedRange.php
+++ b/src/Assertion/Numeric/IsOutOfClosedRange.php
@@ -18,16 +18,21 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsOutOfClosedRange implements Assertion
 {
-    private int|float $min;
+    /** @var T */
+    private $min;
 
-    private int|float $max;
+    /** @var T */
+    private $max;
 
     /**
-     * @param int|float $min
-     * @param int|float $max
+     * @param T $min
+     * @param T $max
      */
     public function __construct($min, $max)
     {
@@ -38,8 +43,8 @@ final class IsOutOfClosedRange implements Assertion
         $this->max = $max;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -54,10 +59,11 @@ final class IsOutOfClosedRange implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
-        (new IsNumeric())->assert($value);
+        (new IsNumeric())
+            ->assert($value);
 
         return ($value < $this->min) || ($this->max < $value);
     }

--- a/src/Assertion/Numeric/IsOutOfOpenRange.php
+++ b/src/Assertion/Numeric/IsOutOfOpenRange.php
@@ -24,23 +24,14 @@ use function sprintf;
  */
 final class IsOutOfOpenRange implements Assertion
 {
-    /** @var T */
-    private $min;
-
-    /** @var T */
-    private $max;
-
     /**
      * @param T $min
      * @param T $max
      */
-    public function __construct($min, $max)
+    public function __construct(private $min, private $max)
     {
         (new IsLessThan($max))
             ->assert($min, 'Lower bound must be lower than upper bound. Got (%1$s, %2$s).');
-
-        $this->min = $min;
-        $this->max = $max;
     }
 
     /** @psalm-assert T $value */
@@ -59,7 +50,7 @@ final class IsOutOfOpenRange implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true T $value */
+    /** @psalm-assert T $value */
     public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);

--- a/src/Assertion/Numeric/IsOutOfOpenRange.php
+++ b/src/Assertion/Numeric/IsOutOfOpenRange.php
@@ -18,16 +18,21 @@ use Vivarium\Assertion\Type\IsNumeric;
 
 use function sprintf;
 
-/** @template-implements Assertion<int|float> */
+/**
+ * @template T as int|float
+ * @template-implements Assertion<T>
+ */
 final class IsOutOfOpenRange implements Assertion
 {
-    private int|float $min;
+    /** @var T */
+    private $min;
 
-    private int|float $max;
+    /** @var T */
+    private $max;
 
     /**
-     * @param int|float $min
-     * @param int|float $max
+     * @param T $min
+     * @param T $max
      */
     public function __construct($min, $max)
     {
@@ -38,8 +43,8 @@ final class IsOutOfOpenRange implements Assertion
         $this->max = $max;
     }
 
-    /** @param int|float $value */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -54,8 +59,8 @@ final class IsOutOfOpenRange implements Assertion
         }
     }
 
-    /** @param int|float $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsNumeric())->assert($value);
 

--- a/src/Assertion/Object/IsInstanceOf.php
+++ b/src/Assertion/Object/IsInstanceOf.php
@@ -23,7 +23,7 @@ use function sprintf;
 
 /**
  * @template T as object
- * @template-implements Assertion<object>
+ * @template-implements Assertion<T>
  */
 final class IsInstanceOf implements Assertion
 {
@@ -40,14 +40,8 @@ final class IsInstanceOf implements Assertion
         ))->assert($class, 'Argument must be a class or interface name. Got %s');
     }
 
-    /**
-     * @param object $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert T $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -61,14 +55,8 @@ final class IsInstanceOf implements Assertion
         }
     }
 
-    /**
-     * @param object $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert-if-true T $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsObject())->assert($value);
 

--- a/src/Assertion/String/Contains.php
+++ b/src/Assertion/String/Contains.php
@@ -16,7 +16,7 @@ use Vivarium\Assertion\Helpers\TypeToString;
 use Vivarium\Assertion\Type\IsString;
 
 use function sprintf;
-use function strpos;
+use function str_contains;
 
 /** @template-implements Assertion<string> */
 final class Contains implements Assertion
@@ -25,12 +25,8 @@ final class Contains implements Assertion
     {
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -44,11 +40,11 @@ final class Contains implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 
-        return strpos($value, $this->substring, 0) !== false;
+        return str_contains($value, $this->substring);
     }
 }

--- a/src/Assertion/String/Contains.php
+++ b/src/Assertion/String/Contains.php
@@ -40,7 +40,7 @@ final class Contains implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/EndsWith.php
+++ b/src/Assertion/String/EndsWith.php
@@ -42,7 +42,7 @@ final class EndsWith implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/EndsWith.php
+++ b/src/Assertion/String/EndsWith.php
@@ -27,12 +27,8 @@ final class EndsWith implements Assertion
     {
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -46,8 +42,8 @@ final class EndsWith implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsClass.php
+++ b/src/Assertion/String/IsClass.php
@@ -35,7 +35,7 @@ final class IsClass implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true class-string $value */
+    /** @psalm-assert class-string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/IsClass.php
+++ b/src/Assertion/String/IsClass.php
@@ -18,17 +18,11 @@ use Vivarium\Assertion\Type\IsString;
 use function class_exists;
 use function sprintf;
 
-/** @template-implements Assertion<string> */
+/** @template-implements Assertion<class-string> */
 final class IsClass implements Assertion
 {
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert class-string $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert class-string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -41,20 +35,11 @@ final class IsClass implements Assertion
         }
     }
 
-    /**
-     * @param string $value
-     *
-     * @psalm-assert-if-true class-string $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true class-string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 
-        /**
-         * This function triggers the autoload but i think is an acceptable side effect
-         *
-         * @psalm-suppress ImpureFunctionCall
-         */
         return class_exists($value);
     }
 }

--- a/src/Assertion/String/IsClassOrInterface.php
+++ b/src/Assertion/String/IsClassOrInterface.php
@@ -12,12 +12,11 @@ namespace Vivarium\Assertion\String;
 
 use Vivarium\Assertion\Assertion;
 use Vivarium\Assertion\Conditional\Either;
-use Vivarium\Assertion\Exception\AssertionFailed;
 
-/** @template-implements Assertion<string> */
+/** @template-implements Assertion<class-string> */
 final class IsClassOrInterface implements Assertion
 {
-    /** @var Assertion<string> */
+    /** @var Assertion<class-string> */
     private Assertion $assertion;
 
     public function __construct()
@@ -28,14 +27,8 @@ final class IsClassOrInterface implements Assertion
         );
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert class-string $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert class-string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         $message = (new IsEmpty())($message) ?
             'Argument must be a class or interface name. Got %s' : $message;
@@ -43,12 +36,8 @@ final class IsClassOrInterface implements Assertion
         $this->assertion->assert($value, $message);
     }
 
-    /**
-     * @param string $value
-     *
-     * @psalm-assert-if-true class-string $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true class-string $value */
+    public function __invoke(mixed $value): bool
     {
         return ($this->assertion)($value);
     }

--- a/src/Assertion/String/IsClassOrInterface.php
+++ b/src/Assertion/String/IsClassOrInterface.php
@@ -36,7 +36,7 @@ final class IsClassOrInterface implements Assertion
         $this->assertion->assert($value, $message);
     }
 
-    /** @psalm-assert-if-true class-string $value */
+    /** @psalm-assert class-string $value */
     public function __invoke(mixed $value): bool
     {
         return ($this->assertion)($value);

--- a/src/Assertion/String/IsEmpty.php
+++ b/src/Assertion/String/IsEmpty.php
@@ -21,12 +21,8 @@ use function strlen;
 /** @template-implements Assertion<string> */
 final class IsEmpty implements Assertion
 {
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -39,8 +35,8 @@ final class IsEmpty implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsEmpty.php
+++ b/src/Assertion/String/IsEmpty.php
@@ -35,7 +35,7 @@ final class IsEmpty implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/IsInterface.php
+++ b/src/Assertion/String/IsInterface.php
@@ -35,7 +35,7 @@ final class IsInterface implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true class-string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/IsInterface.php
+++ b/src/Assertion/String/IsInterface.php
@@ -18,17 +18,11 @@ use Vivarium\Assertion\Type\IsString;
 use function interface_exists;
 use function sprintf;
 
-/** @template-implements Assertion<string> */
+/** @template-implements Assertion<class-string> */
 final class IsInterface implements Assertion
 {
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert class-string $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert class-string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -41,12 +35,8 @@ final class IsInterface implements Assertion
         }
     }
 
-    /**
-     * @param string $value
-     *
-     * @psalm-assert-if-true class-string $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true class-string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsLong.php
+++ b/src/Assertion/String/IsLong.php
@@ -30,7 +30,6 @@ final class IsLong implements Assertion
     /** @psalm-assert string $value */
     public function assert(mixed $value, string $message = ''): void
     {
-        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -44,7 +43,7 @@ final class IsLong implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())

--- a/src/Assertion/String/IsLong.php
+++ b/src/Assertion/String/IsLong.php
@@ -27,13 +27,10 @@ final class IsLong implements Assertion
         (new IsSystemEncoding())->assert($encoding);
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
+        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -47,10 +44,11 @@ final class IsLong implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
-        (new IsString())->assert($value);
+        (new IsString())
+            ->assert($value);
 
         return mb_strlen($value, $this->encoding) === $this->length;
     }

--- a/src/Assertion/String/IsLongAtLeast.php
+++ b/src/Assertion/String/IsLongAtLeast.php
@@ -29,13 +29,10 @@ final class IsLongAtLeast implements Assertion
         (new IsGreaterThan(0))->assert($length);
     }
 
-    /**
-     * @param string $value
-     *
-     *  @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
+        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -49,8 +46,8 @@ final class IsLongAtLeast implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsLongAtLeast.php
+++ b/src/Assertion/String/IsLongAtLeast.php
@@ -32,7 +32,6 @@ final class IsLongAtLeast implements Assertion
     /** @psalm-assert string $value */
     public function assert(mixed $value, string $message = ''): void
     {
-        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -46,7 +45,7 @@ final class IsLongAtLeast implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/IsLongAtMax.php
+++ b/src/Assertion/String/IsLongAtMax.php
@@ -32,7 +32,6 @@ final class IsLongAtMax implements Assertion
     /** @psalm-assert string $value */
     public function assert(mixed $value, string $message = ''): void
     {
-        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -46,7 +45,7 @@ final class IsLongAtMax implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/IsLongAtMax.php
+++ b/src/Assertion/String/IsLongAtMax.php
@@ -29,13 +29,10 @@ final class IsLongAtMax implements Assertion
         (new IsGreaterThan(0))->assert($length);
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
+        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -49,8 +46,8 @@ final class IsLongAtMax implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsLongBetween.php
+++ b/src/Assertion/String/IsLongBetween.php
@@ -27,13 +27,10 @@ final class IsLongBetween implements Assertion
         (new IsSystemEncoding())->assert($encoding);
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
+        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -48,8 +45,8 @@ final class IsLongBetween implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/String/IsLongBetween.php
+++ b/src/Assertion/String/IsLongBetween.php
@@ -30,7 +30,6 @@ final class IsLongBetween implements Assertion
     /** @psalm-assert string $value */
     public function assert(mixed $value, string $message = ''): void
     {
-        /** @var string $value */
         if (! $this($value)) {
             $message = sprintf(
                 ! (new IsEmpty())($message) ?
@@ -45,7 +44,7 @@ final class IsLongBetween implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/StartsWith.php
+++ b/src/Assertion/String/StartsWith.php
@@ -42,7 +42,7 @@ final class StartsWith implements Assertion
         }
     }
 
-    /** @psalm-assert-if-true string $value */
+    /** @psalm-assert string $value */
     public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);

--- a/src/Assertion/String/StartsWith.php
+++ b/src/Assertion/String/StartsWith.php
@@ -27,12 +27,8 @@ final class StartsWith implements Assertion
     {
     }
 
-    /**
-     * @param string $value
-     *
-     * @throws AssertionFailed
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -46,8 +42,8 @@ final class StartsWith implements Assertion
         }
     }
 
-    /** @param string $value */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         (new IsString())->assert($value);
 

--- a/src/Assertion/Type/IsArray.php
+++ b/src/Assertion/Type/IsArray.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_array;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<array> */
 final class IsArray implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert array $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert array $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsArray implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true array $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true array $value */
+    public function __invoke(mixed $value): bool
     {
         return is_array($value);
     }

--- a/src/Assertion/Type/IsBoolean.php
+++ b/src/Assertion/Type/IsBoolean.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_bool;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<bool> */
 final class IsBoolean implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert bool $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert bool $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsBoolean implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true bool $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true bool $value */
+    public function __invoke(mixed $value): bool
     {
         return is_bool($value);
     }

--- a/src/Assertion/Type/IsCallable.php
+++ b/src/Assertion/Type/IsCallable.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_callable;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<callable> */
 final class IsCallable implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert callable $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert callable $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsCallable implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true callable $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true callable $value */
+    public function __invoke(mixed $value): bool
     {
         return is_callable($value);
     }

--- a/src/Assertion/Type/IsFloat.php
+++ b/src/Assertion/Type/IsFloat.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_float;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<float> */
 final class IsFloat implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert float $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert float $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsFloat implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true float $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true float $value */
+    public function __invoke(mixed $value): bool
     {
         return is_float($value);
     }

--- a/src/Assertion/Type/IsInteger.php
+++ b/src/Assertion/Type/IsInteger.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_int;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<int> */
 final class IsInteger implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert int $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert int $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsInteger implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true int $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true int $value */
+    public function __invoke(mixed $value): bool
     {
         return is_int($value);
     }

--- a/src/Assertion/Type/IsNumeric.php
+++ b/src/Assertion/Type/IsNumeric.php
@@ -12,13 +12,15 @@ namespace Vivarium\Assertion\Type;
 
 use Vivarium\Assertion\Assertion;
 use Vivarium\Assertion\Conditional\Either;
-use Vivarium\Assertion\Exception\AssertionFailed;
 use Vivarium\Assertion\String\IsEmpty;
 
-/** @template-implements Assertion<mixed> */
+/**
+ * @template T of int|float
+ * @template-implements Assertion<T>
+ */
 final class IsNumeric implements Assertion
 {
-    /** @var Assertion<mixed> */
+    /** @var Either<int, float> */
     private Assertion $isNumeric;
 
     public function __construct()
@@ -29,14 +31,8 @@ final class IsNumeric implements Assertion
         );
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert int|float $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert T $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         $this->isNumeric->assert(
             $value,
@@ -45,12 +41,8 @@ final class IsNumeric implements Assertion
         );
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true int|float $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true T $value */
+    public function __invoke(mixed $value): bool
     {
         return ($this->isNumeric)($value);
     }

--- a/src/Assertion/Type/IsObject.php
+++ b/src/Assertion/Type/IsObject.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_object;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<object> */
 final class IsObject implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert object $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert object $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsObject implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true object $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true object $value */
+    public function __invoke(mixed $value): bool
     {
         return is_object($value);
     }

--- a/src/Assertion/Type/IsString.php
+++ b/src/Assertion/Type/IsString.php
@@ -19,17 +19,11 @@ use function gettype;
 use function is_string;
 use function sprintf;
 
-/** @template-implements Assertion<mixed> */
+/** @template-implements Assertion<string> */
 final class IsString implements Assertion
 {
-    /**
-     * @param mixed $value
-     *
-     * @throws AssertionFailed
-     *
-     * @psalm-assert string $value
-     */
-    public function assert($value, string $message = ''): void
+    /** @psalm-assert string $value */
+    public function assert(mixed $value, string $message = ''): void
     {
         if (! $this($value)) {
             $message = sprintf(
@@ -43,12 +37,8 @@ final class IsString implements Assertion
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @psalm-assert-if-true string $value
-     */
-    public function __invoke($value): bool
+    /** @psalm-assert-if-true string $value */
+    public function __invoke(mixed $value): bool
     {
         return is_string($value);
     }

--- a/tests/Assertion/Boolean/IsFalseTest.php
+++ b/tests/Assertion/Boolean/IsFalseTest.php
@@ -21,13 +21,25 @@ final class IsFalseTest extends TestCase
      * @covers ::assert()
      * @covers ::__invoke()
      */
-    public function testAssert(): void
+    function testAssert() : void
+    {
+        static::expectNotToPerformAssertions();
+
+        (new IsFalse())
+            ->assert(false);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
     {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected boolean to be false. Got true');
 
-        (new IsFalse())->assert(false);
-        (new IsFalse())->assert(true);
+        (new IsFalse())
+            ->assert(true);
     }
 
     /**
@@ -39,12 +51,7 @@ final class IsFalseTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be boolean. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsFalse())->assert(42);
+        (new IsFalse())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Boolean/IsFalseTest.php
+++ b/tests/Assertion/Boolean/IsFalseTest.php
@@ -21,7 +21,7 @@ final class IsFalseTest extends TestCase
      * @covers ::assert()
      * @covers ::__invoke()
      */
-    function testAssert() : void
+    public function testAssert(): void
     {
         static::expectNotToPerformAssertions();
 

--- a/tests/Assertion/Boolean/IsTrueTest.php
+++ b/tests/Assertion/Boolean/IsTrueTest.php
@@ -23,11 +23,24 @@ final class IsTrueTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsTrue())
+            ->assert(true);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected boolean to be true. Got false.');
 
-        (new IsTrue())->assert(true);
-        (new IsTrue())->assert(false);
+
+        (new IsTrue())
+            ->assert(false);
     }
 
     /**
@@ -39,12 +52,7 @@ final class IsTrueTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be boolean. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsTrue())->assert(42);
+        (new IsTrue())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Boolean/IsTrueTest.php
+++ b/tests/Assertion/Boolean/IsTrueTest.php
@@ -38,7 +38,6 @@ final class IsTrueTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected boolean to be true. Got false.');
 
-
         (new IsTrue())
             ->assert(false);
     }

--- a/tests/Assertion/Comparison/IsEqualsToTest.php
+++ b/tests/Assertion/Comparison/IsEqualsToTest.php
@@ -13,7 +13,6 @@ namespace Vivarium\Test\Assertion\Comparison;
 use PHPUnit\Framework\TestCase;
 use Vivarium\Assertion\Comparison\IsEqualsTo;
 use Vivarium\Assertion\Exception\AssertionFailed;
-use Vivarium\Equality\Equality;
 
 /** @coversDefaultClass \Vivarium\Assertion\Comparison\IsEqualsTo */
 final class IsEqualsToTest extends TestCase
@@ -40,7 +39,6 @@ final class IsEqualsToTest extends TestCase
     {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be equals to "RandomString". Got "Hello World"');
-
 
         (new IsEqualsTo('RandomString'))
             ->assert('Hello World');

--- a/tests/Assertion/Comparison/IsEqualsToTest.php
+++ b/tests/Assertion/Comparison/IsEqualsToTest.php
@@ -25,11 +25,10 @@ final class IsEqualsToTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected value to be equals to "RandomString". Got "Hello World"');
+        static::expectNotToPerformAssertions();
 
-        (new IsEqualsTo(5))->assert(5);
-        (new IsEqualsTo('RandomString'))->assert('Hello World');
+        (new IsEqualsTo(5))
+            ->assert(5);
     }
 
     /**
@@ -37,21 +36,13 @@ final class IsEqualsToTest extends TestCase
      * @covers ::assert()
      * @covers ::__invoke()
      */
-    public function testAssertWithEqualityInterface(): void
+    public function testAssertException(): void
     {
         static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected objects to be equals.');
+        static::expectExceptionMessage('Expected value to be equals to "RandomString". Got "Hello World"');
 
-        $equality  = $this->createMock(Equality::class);
-        $equality1 = $this->createMock(Equality::class);
 
-        $equality1
-            ->expects(static::once())
-            ->method('equals')
-            ->with($equality)
-            ->willReturn(false);
-
-        (new IsEqualsTo($equality))
-            ->assert($equality1, 'Expected objects to be equals.');
+        (new IsEqualsTo('RandomString'))
+            ->assert('Hello World');
     }
 }

--- a/tests/Assertion/Comparison/IsOneOfTest.php
+++ b/tests/Assertion/Comparison/IsOneOfTest.php
@@ -13,7 +13,6 @@ namespace Vivarium\Test\Assertion\Comparison;
 use PHPUnit\Framework\TestCase;
 use Vivarium\Assertion\Comparison\IsOneOf;
 use Vivarium\Assertion\Exception\AssertionFailed;
-use Vivarium\Equality\Equality;
 
 /** @coversDefaultClass \Vivarium\Assertion\Comparison\IsOneOf */
 final class IsOneOfTest extends TestCase

--- a/tests/Assertion/Comparison/IsOneOfTest.php
+++ b/tests/Assertion/Comparison/IsOneOfTest.php
@@ -25,8 +25,7 @@ final class IsOneOfTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected value to be one of the values provided. Got 27.');
+        static::expectNotToPerformAssertions();
 
         $oneOf = new IsOneOf(1, 5, 7, 42);
 
@@ -34,8 +33,6 @@ final class IsOneOfTest extends TestCase
         $oneOf->assert(5);
         $oneOf->assert(7);
         $oneOf->assert(42);
-
-        $oneOf->assert(27);
     }
 
     /**
@@ -43,23 +40,12 @@ final class IsOneOfTest extends TestCase
      * @covers ::assert()
      * @covers ::__invoke()
      */
-    public function testAssertWithEquality(): void
+    public function testAssertException(): void
     {
         static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected value to be one of the values provided. Got different object.');
+        static::expectExceptionMessage('Expected value to be one of the values provided. Got 27.');
 
-        $element1 = $this->createMock(Equality::class);
-        $element2 = $this->createMock(Equality::class);
-        $element3 = $this->createMock(Equality::class);
-        $element4 = $this->createMock(Equality::class);
-
-        $search = $this->createMock(Equality::class);
-        $search
-            ->expects(static::exactly(4))
-            ->method('equals')
-            ->withConsecutive([$element1], [$element2], [$element3], [$element4])
-            ->willReturn(false);
-
-        (new IsOneOf($element1, $element2, $element3, $element4))->assert($search);
+        (new IsOneOf(1, 5, 7, 42))
+            ->assert(27);
     }
 }

--- a/tests/Assertion/Comparison/IsSameOfTest.php
+++ b/tests/Assertion/Comparison/IsSameOfTest.php
@@ -25,12 +25,27 @@ final class IsSameOfTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsSameOf(42))
+            ->assert(42);
+
+        $stdClass = new stdClass();
+        (new IsSameOf($stdClass))
+            ->assert($stdClass);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be the same of "stdClass". Got different object.');
 
-        $stdClass = new stdClass();
-        (new IsSameOf(42))->assert(42);
-        (new IsSameOf($stdClass))->assert($stdClass);
-        (new IsSameOf($stdClass))->assert(new stdClass());
+        (new IsSameOf(new stdClass()))
+            ->assert(new stdClass());
     }
 }

--- a/tests/Assertion/Conditional/AllTest.php
+++ b/tests/Assertion/Conditional/AllTest.php
@@ -13,8 +13,6 @@ namespace Vivarium\Test\Assertion\Conditional;
 use PHPUnit\Framework\TestCase;
 use Vivarium\Assertion\Conditional\All;
 use Vivarium\Assertion\Exception\AssertionFailed;
-use Vivarium\Assertion\Numeric\IsGreaterThan;
-use Vivarium\Assertion\Numeric\IsLessOrEqualThan;
 use Vivarium\Assertion\String\Contains;
 use Vivarium\Assertion\String\IsLongAtLeast;
 use Vivarium\Assertion\Type\IsString;
@@ -32,7 +30,7 @@ final class AllTest extends TestCase
 
         (new All(
             new IsString(),
-            new IsLongAtLeast(5)
+            new IsLongAtLeast(5),
         ))->assert('Hello');
     }
 
@@ -62,7 +60,7 @@ final class AllTest extends TestCase
 
         (new All(
             new IsString(),
-            new IsLongAtLeast(5)
+            new IsLongAtLeast(5),
         ))->assert('Hi');
     }
 
@@ -71,7 +69,7 @@ final class AllTest extends TestCase
     {
         $assertion = (new All(
             new IsString(),
-            new IsLongAtLeast(5)
+            new IsLongAtLeast(5),
         ));
 
         static::assertTrue($assertion('Hello'));
@@ -85,7 +83,7 @@ final class AllTest extends TestCase
     {
         $assertion = (new All(
             new IsString(),
-            new IsLongAtLeast(5)
+            new IsLongAtLeast(5),
         ));
 
         static::assertFalse($assertion(7));

--- a/tests/Assertion/Conditional/AllTest.php
+++ b/tests/Assertion/Conditional/AllTest.php
@@ -17,6 +17,7 @@ use Vivarium\Assertion\Numeric\IsGreaterThan;
 use Vivarium\Assertion\Numeric\IsLessOrEqualThan;
 use Vivarium\Assertion\String\Contains;
 use Vivarium\Assertion\String\IsLongAtLeast;
+use Vivarium\Assertion\Type\IsString;
 
 /** @coversDefaultClass \Vivarium\Assertion\Conditional\All */
 final class AllTest extends TestCase
@@ -27,13 +28,22 @@ final class AllTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected string to be long at least 10. Got 6.');
+        static::expectNotToPerformAssertions();
 
         (new All(
-            new IsGreaterThan(0),
-            new IsLessOrEqualThan(7),
-        ))->assert(5);
+            new IsString(),
+            new IsLongAtLeast(5)
+        ))->assert('Hello');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected string to be long at least 10. Got 6.');
 
         (new All(
             new IsLongAtLeast(10),
@@ -48,23 +58,23 @@ final class AllTest extends TestCase
     public function testAssertFailLater(): void
     {
         static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected number to be less or equal than 1. Got 5.');
+        static::expectExceptionMessage('Expected string to be long at least 5. Got 2.');
 
         (new All(
-            new IsGreaterThan(0),
-            new IsLessOrEqualThan(1),
-        ))->assert(5);
+            new IsString(),
+            new IsLongAtLeast(5)
+        ))->assert('Hi');
     }
 
     /** @covers ::__invoke() */
     public function testInvoke(): void
     {
-        $assertion1 = (new All(
-            new IsGreaterThan(0),
-            new IsLessOrEqualThan(7),
+        $assertion = (new All(
+            new IsString(),
+            new IsLongAtLeast(5)
         ));
 
-        static::assertTrue($assertion1(5));
+        static::assertTrue($assertion('Hello'));
     }
 
     /**
@@ -74,8 +84,8 @@ final class AllTest extends TestCase
     public function testInvokeFail(): void
     {
         $assertion = (new All(
-            new IsGreaterThan(0),
-            new IsLessOrEqualThan(1),
+            new IsString(),
+            new IsLongAtLeast(5)
         ));
 
         static::assertFalse($assertion(7));

--- a/tests/Assertion/Conditional/EachTest.php
+++ b/tests/Assertion/Conditional/EachTest.php
@@ -14,11 +14,8 @@ use PHPUnit\Framework\TestCase;
 use Traversable;
 use Vivarium\Assertion\Conditional\Each;
 use Vivarium\Assertion\Exception\AssertionFailed;
-use Vivarium\Assertion\Numeric\IsGreaterOrEqualThan;
 use Vivarium\Assertion\Numeric\IsInClosedRange;
-use Vivarium\Assertion\Numeric\IsLessThan;
 use Vivarium\Assertion\Object\IsInstanceOf;
-use Vivarium\Assertion\String\IsInterface;
 use Vivarium\Assertion\String\IsLongAtLeast;
 use Vivarium\Assertion\Type\IsInteger;
 
@@ -59,7 +56,7 @@ final class EachTest extends TestCase
         static::expectExceptionMessage('Element at index 2 failed the assertion.');
 
         (new Each(
-            new IsInteger()
+            new IsInteger(),
         ))->assert([0, 9, '3', 42]);
     }
 

--- a/tests/Assertion/Conditional/EachTest.php
+++ b/tests/Assertion/Conditional/EachTest.php
@@ -18,7 +18,9 @@ use Vivarium\Assertion\Numeric\IsGreaterOrEqualThan;
 use Vivarium\Assertion\Numeric\IsInClosedRange;
 use Vivarium\Assertion\Numeric\IsLessThan;
 use Vivarium\Assertion\Object\IsInstanceOf;
+use Vivarium\Assertion\String\IsInterface;
 use Vivarium\Assertion\String\IsLongAtLeast;
+use Vivarium\Assertion\Type\IsInteger;
 
 /** @coversDefaultClass \Vivarium\Assertion\Conditional\Each */
 final class EachTest extends TestCase
@@ -54,12 +56,11 @@ final class EachTest extends TestCase
     public function testAssertFailLater(): void
     {
         static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Element at index 3 failed the assertion.');
+        static::expectExceptionMessage('Element at index 2 failed the assertion.');
 
         (new Each(
-            new IsGreaterOrEqualThan(0),
-            new IsLessThan(10),
-        ))->assert([0, 9, 3, 42]);
+            new IsInteger()
+        ))->assert([0, 9, '3', 42]);
     }
 
     /**
@@ -71,14 +72,9 @@ final class EachTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be array. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidArgument
-         */
         (new Each(
             new IsLongAtLeast(27),
-        ))->assert(42); /* @phpstan-ignore-line */
+        ))->assert(42);
     }
 
     /** @covers ::__invoke() */
@@ -98,13 +94,8 @@ final class EachTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be array. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidArgument
-         */
         (new Each(
             new IsLongAtLeast(27),
-        ))(42); /* @phpstan-ignore-line */
+        ))(42);
     }
 }

--- a/tests/Assertion/Conditional/EitherTest.php
+++ b/tests/Assertion/Conditional/EitherTest.php
@@ -27,6 +27,20 @@ final class EitherTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new Either(
+            new IsGreaterThan(100),
+            new IsInClosedRange(0, 9),
+        ))->assert(6);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Failed all assertions in either condition.');
 

--- a/tests/Assertion/Conditional/NotTest.php
+++ b/tests/Assertion/Conditional/NotTest.php
@@ -24,13 +24,25 @@ final class NotTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new Not(new IsString()))
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage(
             'Failed negating the assertion "Vivarium\Assertion\Type\IsString" with value "Hello World".',
         );
 
-        (new Not(new IsString()))->assert(42);
-        (new Not(new IsString()))->assert('Hello World');
+        (new Not(new IsString()))
+            ->assert('Hello World');
     }
 
     /** @covers ::__invoke() */

--- a/tests/Assertion/Conditional/NullOrTest.php
+++ b/tests/Assertion/Conditional/NullOrTest.php
@@ -26,11 +26,21 @@ final class NullOrTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(InvalidArgumentException::class);
-        static::expectExceptionMessage('Expected value to be string. Got array.');
+        static::expectNotToPerformAssertions();
 
         (new NullOr(new IsString()))->assert('Hello World');
         (new NullOr(new IsString()))->assert(null);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(InvalidArgumentException::class);
+        static::expectExceptionMessage('Expected value to be string. Got array.');
+
         (new NullOr(new IsString()))->assert([]);
     }
 

--- a/tests/Assertion/Encoding/IsEncodingTest.php
+++ b/tests/Assertion/Encoding/IsEncodingTest.php
@@ -23,6 +23,18 @@ final class IsEncodingTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsEncoding())->assert('UTF-8');
+        (new IsEncoding())('UTF-8');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Windows-1251" is not a valid encoding.');
 
@@ -40,12 +52,6 @@ final class IsEncodingTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
         (new IsEncoding())->assert(42);
     }
 }

--- a/tests/Assertion/Encoding/IsRegexEncodingTest.php
+++ b/tests/Assertion/Encoding/IsRegexEncodingTest.php
@@ -25,6 +25,18 @@ final class IsRegexEncodingTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsRegexEncoding())->assert('UTF-8');
+        (new IsRegexEncoding())('UTF-8');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Windows-1251" is not a valid regex encoding.');
 
@@ -52,12 +64,6 @@ final class IsRegexEncodingTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
         (new IsRegexEncoding())->assert(42);
     }
 }

--- a/tests/Assertion/Encoding/IsSystemEncodingTest.php
+++ b/tests/Assertion/Encoding/IsSystemEncodingTest.php
@@ -25,11 +25,21 @@ final class IsSystemEncodingTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('"Foo" is not a valid system encoding');
+        static::expectNotToPerformAssertions();
 
         (new IsSystemEncoding())->assert('UTF-8');
         (new IsSystemEncoding())('UTF-8');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('"Foo" is not a valid system encoding');
+
         (new IsSystemEncoding())->assert('Foo');
     }
 
@@ -50,12 +60,6 @@ final class IsSystemEncodingTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
         (new IsSystemEncoding())->assert(42);
     }
 }

--- a/tests/Assertion/Hierarchy/ImplementsInterfaceTest.php
+++ b/tests/Assertion/Hierarchy/ImplementsInterfaceTest.php
@@ -26,13 +26,26 @@ final class ImplementsInterfaceTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected class "stdClass" to implements "Traversable".');
+        static::expectNotToPerformAssertions();
 
         $mock = $this->createMock(Traversable::class);
 
-        (new ImplementsInterface(Traversable::class))->assert($mock::class);
-        (new ImplementsInterface(Traversable::class))->assert(stdClass::class);
+        (new ImplementsInterface(Traversable::class))
+            ->assert($mock::class);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected class "stdClass" to implements "Traversable".');
+
+        (new ImplementsInterface(Traversable::class))
+            ->assert(stdClass::class);
     }
 
     /** @covers ::assert() */
@@ -41,7 +54,8 @@ final class ImplementsInterfaceTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be interface name. Got "stdClass".');
 
-        (new ImplementsInterface(stdClass::class))->assert(stdClass::class);
+        (new ImplementsInterface(stdClass::class))
+            ->assert(stdClass::class);
     }
 
     /**
@@ -53,6 +67,7 @@ final class ImplementsInterfaceTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be a class name. Got "Traversable".');
 
-        (new ImplementsInterface(Traversable::class))->assert(Traversable::class);
+        (new ImplementsInterface(Traversable::class))
+            ->assert(Traversable::class);
     }
 }

--- a/tests/Assertion/Hierarchy/IsAssignableToTest.php
+++ b/tests/Assertion/Hierarchy/IsAssignableToTest.php
@@ -29,6 +29,25 @@ final class IsAssignableToTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsAssignableTo(Stub::class))
+            ->assert(Stub::class);
+
+        (new IsAssignableTo(Stub::class))
+            ->assert(StubClass::class);
+
+        (new IsAssignableTo(StubClass::class))
+            ->assert(StubClassExtension::class);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage(
             sprintf(
@@ -38,10 +57,8 @@ final class IsAssignableToTest extends TestCase
             ),
         );
 
-        (new IsAssignableTo(Stub::class))->assert(Stub::class);
-        (new IsAssignableTo(Stub::class))->assert(StubClass::class);
-        (new IsAssignableTo(StubClass::class))->assert(StubClassExtension::class);
-        (new IsAssignableTo(StubClassExtension::class))->assert(Stub::class);
+        (new IsAssignableTo(StubClassExtension::class))
+            ->assert(Stub::class);
     }
 
     /** @covers ::__construct() */
@@ -51,13 +68,14 @@ final class IsAssignableToTest extends TestCase
         static::expectExceptionMessage('Argument must be a class or interface name. Got "RandomString"');
 
         /**
-         * This is covered by static analysis but it is a valid runtime call
+         * This is covered by static analysis, but it is a valid runtime call
          *
          * @psalm-suppress ArgumentTypeCoercion
          * @psalm-suppress UndefinedClass
          * @phpstan-ignore-next-line
          */
-        (new IsAssignableTo('RandomString'))->assert(Stub::class);
+        (new IsAssignableTo('RandomString'))
+            ->assert(Stub::class);
     }
 
     /**
@@ -70,13 +88,7 @@ final class IsAssignableToTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Argument must be a class or interface name. Got "RandomString"');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress ArgumentTypeCoercion
-         * @psalm-suppress UndefinedClass
-         * @phpstan-ignore-next-line
-         */
-        (new IsAssignableTo(Stub::class))->assert('RandomString');
+        (new IsAssignableTo(Stub::class))
+            ->assert('RandomString');
     }
 }

--- a/tests/Assertion/Hierarchy/IsSubclassOfTest.php
+++ b/tests/Assertion/Hierarchy/IsSubclassOfTest.php
@@ -38,7 +38,6 @@ final class IsSubclassOfTest extends TestCase
             ->assert(StubClassExtension::class);
     }
 
-
     /**
      * @covers ::__construct()
      * @covers ::assert()

--- a/tests/Assertion/Hierarchy/IsSubclassOfTest.php
+++ b/tests/Assertion/Hierarchy/IsSubclassOfTest.php
@@ -29,6 +29,23 @@ final class IsSubclassOfTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsSubclassOf(Stub::class))
+            ->assert(StubClass::class);
+
+        (new IsSubclassOf(StubClass::class))
+            ->assert(StubClassExtension::class);
+    }
+
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage(
             sprintf(
@@ -38,9 +55,8 @@ final class IsSubclassOfTest extends TestCase
             ),
         );
 
-        (new IsSubclassOf(Stub::class))->assert(StubClass::class);
-        (new IsSubclassOf(StubClass::class))->assert(StubClassExtension::class);
-        (new IsSubclassOf(StubClassExtension::class))->assert(StubClass::class);
+        (new IsSubclassOf(StubClassExtension::class))
+            ->assert(StubClass::class);
     }
 
     /** @covers ::__construct() */
@@ -50,13 +66,14 @@ final class IsSubclassOfTest extends TestCase
         static::expectExceptionMessage('Argument must be a class or interface name. Got "RandomString"');
 
         /**
-         * This is covered by static analysis but it is a valid runtime call
+         * This is covered by static analysis, but it is a valid runtime call
          *
          * @psalm-suppress ArgumentTypeCoercion
          * @psalm-suppress UndefinedClass
          * @phpstan-ignore-next-line
          */
-        (new IsSubclassOf('RandomString'))->assert(Stub::class);
+        (new IsSubclassOf('RandomString'))
+            ->assert(Stub::class);
     }
 
     /**
@@ -69,13 +86,7 @@ final class IsSubclassOfTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Argument must be a class or interface name. Got "RandomString"');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress ArgumentTypeCoercion
-         * @psalm-suppress UndefinedClass
-         * @phpstan-ignore-next-line
-         */
-        (new IsSubclassOf(Stub::class))->assert('RandomString');
+        (new IsSubclassOf(Stub::class))
+            ->assert('RandomString');
     }
 }

--- a/tests/Assertion/Numeric/IsGreaterOrEqualThanTest.php
+++ b/tests/Assertion/Numeric/IsGreaterOrEqualThanTest.php
@@ -24,12 +24,27 @@ final class IsGreaterOrEqualThanTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsGreaterOrEqualThan(10))
+            ->assert(10);
+
+        (new IsGreaterOrEqualThan(10))
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be greater or equal than 10. Got 3.');
 
-        (new IsGreaterOrEqualThan(10))->assert(10);
-        (new IsGreaterOrEqualThan(10))->assert(42);
-        (new IsGreaterOrEqualThan(10))->assert(3);
+        (new IsGreaterOrEqualThan(10))
+            ->assert(3);
     }
 
     /**
@@ -41,12 +56,7 @@ final class IsGreaterOrEqualThanTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsGreaterOrEqualThan(10))->assert('String');
+        (new IsGreaterOrEqualThan(10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsGreaterThanTest.php
+++ b/tests/Assertion/Numeric/IsGreaterThanTest.php
@@ -24,11 +24,24 @@ final class IsGreaterThanTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsGreaterThan(10))
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be greater than 10. Got 10.');
 
-        (new IsGreaterThan(10))->assert(42);
-        (new IsGreaterThan(10))->assert(10);
+        (new IsGreaterThan(10))
+            ->assert(10);
     }
 
     /**
@@ -40,12 +53,7 @@ final class IsGreaterThanTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsGreaterThan(10))->assert('String');
+        (new IsGreaterThan(10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsInClosedRangeTest.php
+++ b/tests/Assertion/Numeric/IsInClosedRangeTest.php
@@ -24,13 +24,30 @@ final class IsInClosedRangeTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsInClosedRange(0, 9))
+            ->assert(0);
+
+        (new IsInClosedRange(0, 9))
+            ->assert(9);
+
+        (new IsInClosedRange(0, 9))
+            ->assert(5);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be in closed range [0, 9]. Got 10.');
 
-        (new IsInClosedRange(0, 9))->assert(0);
-        (new IsInClosedRange(0, 9))->assert(9);
-        (new IsInClosedRange(0, 9))->assert(5);
-        (new IsInClosedRange(0, 9))->assert(10);
+        (new IsInClosedRange(0, 9))
+            ->assert(10);
     }
 
     /** @covers ::assert() */
@@ -39,7 +56,8 @@ final class IsInClosedRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Lower bound must be lower or equal than upper bound. Got [10, 0].');
 
-        (new IsInClosedRange(10, 0))->assert(5);
+        (new IsInClosedRange(10, 0))
+            ->assert(5);
     }
 
     /**
@@ -51,12 +69,7 @@ final class IsInClosedRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsInClosedRange(0, 10))->assert('String');
+        (new IsInClosedRange(0, 10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsInOpenRangeTest.php
+++ b/tests/Assertion/Numeric/IsInOpenRangeTest.php
@@ -24,13 +24,35 @@ final class IsInOpenRangeTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+
+
+        (new IsInOpenRange(0, 9))
+            ->assert(5);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::__invoke()
+     */
+    public function testInvoke(): void
+    {
+        static::assertFalse((new IsInOpenRange(0, 9))(0));
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be in open range (0, 9). Got 9.');
 
-        static::assertFalse((new IsInOpenRange(0, 9))(0));
-
-        (new IsInOpenRange(0, 9))->assert(5);
-        (new IsInOpenRange(0, 9))->assert(9);
+        (new IsInOpenRange(0, 9))
+            ->assert(9);
     }
 
     /** @covers ::assert() */
@@ -39,7 +61,8 @@ final class IsInOpenRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Lower bound must be lower than upper bound. Got (10, 0).');
 
-        (new IsInOpenRange(10, 0))->assert(5);
+        (new IsInOpenRange(10, 0))
+            ->assert(5);
     }
 
     /**
@@ -51,12 +74,7 @@ final class IsInOpenRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsInOpenRange(0, 10))->assert('String');
+        (new IsInOpenRange(0, 10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsInOpenRangeTest.php
+++ b/tests/Assertion/Numeric/IsInOpenRangeTest.php
@@ -26,8 +26,6 @@ final class IsInOpenRangeTest extends TestCase
     {
         static::expectNotToPerformAssertions();
 
-
-
         (new IsInOpenRange(0, 9))
             ->assert(5);
     }

--- a/tests/Assertion/Numeric/IsLessOrEqualThanTest.php
+++ b/tests/Assertion/Numeric/IsLessOrEqualThanTest.php
@@ -24,12 +24,27 @@ final class IsLessOrEqualThanTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsLessOrEqualThan(10))
+            ->assert(10);
+
+        (new IsLessOrEqualThan(10))
+            ->assert(5);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be less or equal than 10. Got 42.');
 
-        (new IsLessOrEqualThan(10))->assert(10);
-        (new IsLessOrEqualThan(10))->assert(5);
-        (new IsLessOrEqualThan(10))->assert(42);
+        (new IsLessOrEqualThan(10))
+            ->assert(42);
     }
 
     /**
@@ -41,12 +56,7 @@ final class IsLessOrEqualThanTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLessOrEqualThan(10))->assert('String');
+        (new IsLessOrEqualThan(10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsLessThanTest.php
+++ b/tests/Assertion/Numeric/IsLessThanTest.php
@@ -24,11 +24,23 @@ final class IsLessThanTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsLessThan(10))->assert(5);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be less than 10. Got 10.');
 
-        (new IsLessThan(10))->assert(5);
-        (new IsLessThan(10))->assert(10);
+        (new IsLessThan(10))
+            ->assert(10);
     }
 
     /**
@@ -40,12 +52,7 @@ final class IsLessThanTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLessThan(10))->assert('String');
+        (new IsLessThan(10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsOutOfClosedRangeTest.php
+++ b/tests/Assertion/Numeric/IsOutOfClosedRangeTest.php
@@ -24,14 +24,35 @@ final class IsOutOfClosedRangeTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsOutOfClosedRange(0, 9))
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testInvoke(): void
+    {
+        static::assertFalse((new IsOutOfClosedRange(0, 9))(0));
+        static::assertFalse((new IsOutOfClosedRange(0, 9))(9));
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be out of closed range [0, 9]. Got 5.');
 
-        static::assertFalse((new IsOutOfClosedRange(0, 9))(0));
-        static::assertFalse((new IsOutOfClosedRange(0, 9))(9));
-
-        (new IsOutOfClosedRange(0, 9))->assert(42);
-        (new IsOutOfClosedRange(0, 9))->assert(5);
+        (new IsOutOfClosedRange(0, 9))
+            ->assert(5);
     }
 
     /** @covers ::assert() */
@@ -52,12 +73,7 @@ final class IsOutOfClosedRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsOutOfClosedRange(0, 10))->assert('String');
+        (new IsOutOfClosedRange(0, 10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Numeric/IsOutOfOpenRangeTest.php
+++ b/tests/Assertion/Numeric/IsOutOfOpenRangeTest.php
@@ -24,14 +24,26 @@ final class IsOutOfOpenRangeTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected value to be out of open range (0, 9). Got 8.');
+        static::expectNotToPerformAssertions();
 
         (new IsOutOfOpenRange(0, 9))->assert(-42);
         (new IsOutOfOpenRange(0, 9))->assert(0);
         (new IsOutOfOpenRange(0, 9))->assert(9);
         (new IsOutOfOpenRange(0, 9))->assert(42);
-        (new IsOutOfOpenRange(0, 9))->assert(8);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected value to be out of open range (0, 9). Got 8.');
+
+        (new IsOutOfOpenRange(0, 9))
+            ->assert(8);
     }
 
     /** @covers ::assert() */
@@ -40,7 +52,8 @@ final class IsOutOfOpenRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Lower bound must be lower than upper bound. Got (10, 0).');
 
-        (new IsOutOfOpenRange(10, 0))->assert(5);
+        (new IsOutOfOpenRange(10, 0))
+            ->assert(5);
     }
 
     /**
@@ -52,12 +65,7 @@ final class IsOutOfOpenRangeTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "String".');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsOutOfOpenRange(0, 10))->assert('String');
+        (new IsOutOfOpenRange(0, 10))
+            ->assert('String');
     }
 }

--- a/tests/Assertion/Object/IsInstanceOfTest.php
+++ b/tests/Assertion/Object/IsInstanceOfTest.php
@@ -27,13 +27,26 @@ final class IsInstanceOfTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected object to be instance of "Traversable". Got "stdClass".');
+        static::expectNotToPerformAssertions();
 
         $stub = $this->createMock(Traversable::class);
 
-        (new IsInstanceOf(Traversable::class))->assert($stub);
-        (new IsInstanceOf(Traversable::class))->assert(new stdClass());
+        (new IsInstanceOf(Traversable::class))
+            ->assert($stub);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected object to be instance of "Traversable". Got "stdClass".');
+
+        (new IsInstanceOf(Traversable::class))
+            ->assert(new stdClass());
     }
 
     /** @covers ::__construct() */
@@ -43,13 +56,14 @@ final class IsInstanceOfTest extends TestCase
         static::expectExceptionMessage('Argument must be a class or interface name. Got "RandomString"');
 
         /**
-         * This is covered by static analysis but it is a valid runtime call
+         * This is covered by static analysis, but it is a valid runtime call
          *
          * @psalm-suppress ArgumentTypeCoercion
          * @psalm-suppress UndefinedClass
          * @phpstan-ignore-next-line
          */
-        (new IsInstanceOf('RandomString'))->assert(new stdClass());
+        (new IsInstanceOf('RandomString'))
+            ->assert(new stdClass());
     }
 
     /** @covers ::__construct() */
@@ -58,12 +72,7 @@ final class IsInstanceOfTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be object. Got string.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsInstanceOf(Stub::class))->assert('Random');
+        (new IsInstanceOf(Stub::class))
+            ->assert('Random');
     }
 }

--- a/tests/Assertion/String/ContainsTest.php
+++ b/tests/Assertion/String/ContainsTest.php
@@ -24,10 +24,21 @@ class ContainsTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new Contains('Bar'))->assert('Foo Bar');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected that string contains "Hello".');
 
-        (new Contains('Bar'))->assert('Foo Bar');
         (new Contains('Hello'))->assert('Foo Bar');
     }
 
@@ -45,12 +56,7 @@ class ContainsTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new Contains('Hello'))->assert(42);
+        (new Contains('Hello'))
+            ->assert(42);
     }
 }

--- a/tests/Assertion/String/EndsWithTest.php
+++ b/tests/Assertion/String/EndsWithTest.php
@@ -24,11 +24,24 @@ class EndsWithTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new EndsWith('d'))
+            ->assert('Hello World');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected that string "Foo Bar" ends with "d".');
 
-        (new EndsWith('d'))->assert('Hello World');
-        (new EndsWith('d'))->assert('Foo Bar');
+        (new EndsWith('d'))
+            ->assert('Foo Bar');
     }
 
     /** @covers ::assert() */
@@ -37,12 +50,7 @@ class EndsWithTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new EndsWith('Hello'))->assert(42);
+        (new EndsWith('Hello'))
+            ->assert(42);
     }
 }

--- a/tests/Assertion/String/IsClassTest.php
+++ b/tests/Assertion/String/IsClassTest.php
@@ -23,11 +23,23 @@ final class IsClassTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsClass())
+            ->assert('stdClass');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be a class name. Got "Foo".');
 
-        (new IsClass())->assert('stdClass');
-        (new IsClass())->assert('Foo');
+        (new IsClass())
+            ->assert('Foo');
     }
 
     /** @covers ::assert() */
@@ -36,12 +48,7 @@ final class IsClassTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsClass())->assert(42);
+        (new IsClass())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/String/IsEmptyTest.php
+++ b/tests/Assertion/String/IsEmptyTest.php
@@ -23,11 +23,23 @@ final class IsEmptyTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsEmpty())
+            ->assert('');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be empty. Got "Hello World".');
 
-        (new IsEmpty())->assert('');
-        (new IsEmpty())->assert('Hello World');
+        (new IsEmpty())
+            ->assert('Hello World');
     }
 
     /** @covers ::assert() */
@@ -36,12 +48,7 @@ final class IsEmptyTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsEmpty())->assert(42);
+        (new IsEmpty())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/String/IsInterfaceTest.php
+++ b/tests/Assertion/String/IsInterfaceTest.php
@@ -23,11 +23,23 @@ final class IsInterfaceTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsInterface())
+            ->assert('Traversable');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be interface name. Got "Foo".');
 
-        (new IsInterface())->assert('Traversable');
-        (new IsInterface())->assert('Foo');
+        (new IsInterface())
+            ->assert('Foo');
     }
 
     /** @covers ::assert() */
@@ -36,12 +48,7 @@ final class IsInterfaceTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsInterface())->assert(42);
+        (new IsInterface())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/String/IsLongAtLeastTest.php
+++ b/tests/Assertion/String/IsLongAtLeastTest.php
@@ -24,12 +24,24 @@ final class IsLongAtLeastTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected string to be long at least 6. Got 5');
+        static::expectNotToPerformAssertions();
 
         (new IsLongAtLeast(3))->assert('Hello');
         (new IsLongAtLeast(5))->assert('Hello');
-        (new IsLongAtLeast(6))->assert('Hello');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected string to be long at least 6. Got 5');
+
+        (new IsLongAtLeast(6))
+            ->assert('Hello');
     }
 
     /**
@@ -42,7 +54,8 @@ final class IsLongAtLeastTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Foo" is not a valid system encoding.');
 
-        (new IsLongAtLeast(3, 'Foo'))->assert('Hello');
+        (new IsLongAtLeast(3, 'Foo'))
+            ->assert('Hello');
     }
 
     /**
@@ -55,7 +68,8 @@ final class IsLongAtLeastTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be greater than 0. Got 0.');
 
-        (new IsLongAtLeast(0))->assert('Hello');
+        (new IsLongAtLeast(0))
+            ->assert('Hello');
     }
 
     /** @covers ::assert() */
@@ -64,13 +78,9 @@ final class IsLongAtLeastTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLongAtLeast(5))->assert(42);
+
+        (new IsLongAtLeast(5))
+            ->assert(42);
     }
 
     /** @covers ::assert() */
@@ -79,6 +89,7 @@ final class IsLongAtLeastTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long at least 2. Got 1.');
 
-        (new IsLongAtLeast(2, 'UTF-8'))->assert('π');
+        (new IsLongAtLeast(2, 'UTF-8'))
+            ->assert('π');
     }
 }

--- a/tests/Assertion/String/IsLongAtLeastTest.php
+++ b/tests/Assertion/String/IsLongAtLeastTest.php
@@ -78,7 +78,6 @@ final class IsLongAtLeastTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-
         (new IsLongAtLeast(5))
             ->assert(42);
     }

--- a/tests/Assertion/String/IsLongAtMaxTest.php
+++ b/tests/Assertion/String/IsLongAtMaxTest.php
@@ -24,12 +24,24 @@ final class IsLongAtMaxTest extends TestCase
      */
     public function testAssert(): void
     {
-        static::expectException(AssertionFailed::class);
-        static::expectExceptionMessage('Expected string to be long at max 5. Got 11');
+        static::expectNotToPerformAssertions();
 
         (new IsLongAtMax(6))->assert('Hello');
         (new IsLongAtMax(5))->assert('Hello');
-        (new IsLongAtMax(5))->assert('Hello World');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
+        static::expectException(AssertionFailed::class);
+        static::expectExceptionMessage('Expected string to be long at max 5. Got 11');
+
+        (new IsLongAtMax(5))
+            ->assert('Hello World');
     }
 
     /**
@@ -42,7 +54,8 @@ final class IsLongAtMaxTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Foo" is not a valid system encoding.');
 
-        (new IsLongAtMax(3, 'Foo'))->assert('Hello');
+        (new IsLongAtMax(3, 'Foo'))
+            ->assert('Hello');
     }
 
     /**
@@ -55,7 +68,8 @@ final class IsLongAtMaxTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected number to be greater than 0. Got 0.');
 
-        (new IsLongAtMax(0))->assert('Hello');
+        (new IsLongAtMax(0))
+            ->assert('Hello');
     }
 
     /** @covers ::assert() */
@@ -64,13 +78,8 @@ final class IsLongAtMaxTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLongAtMax(5))->assert(42);
+        (new IsLongAtMax(5))
+            ->assert(42);
     }
 
     /** @covers ::assert() */
@@ -79,7 +88,8 @@ final class IsLongAtMaxTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long at max 1. Got 2.');
 
-        (new IsLongAtMax(1, 'UTF-8'))->assert('ππ');
+        (new IsLongAtMax(1, 'UTF-8'))
+            ->assert('ππ');
     }
 
     /** @covers ::assert() */

--- a/tests/Assertion/String/IsLongBetweenTest.php
+++ b/tests/Assertion/String/IsLongBetweenTest.php
@@ -24,11 +24,25 @@ final class IsLongBetweenTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsLongBetween(1, 5))
+            ->assert('Hello');
+
+        (new IsLongBetween(2, 5))
+            ->assert('Hi');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long between 5 and 10. Got 11');
 
-        (new IsLongBetween(1, 5))->assert('Hello');
-        (new IsLongBetween(2, 5))->assert('Hi');
         (new IsLongBetween(5, 10))->assert('Hello World');
     }
 
@@ -42,7 +56,8 @@ final class IsLongBetweenTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Foo" is not a valid system encoding.');
 
-        (new IsLongBetween(3, 5, 'Foo'))->assert('Hello');
+        (new IsLongBetween(3, 5, 'Foo'))
+            ->assert('Hello');
     }
 
     /** @covers ::assert() */
@@ -51,13 +66,8 @@ final class IsLongBetweenTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLongBetween(0, 5))->assert(42);
+        (new IsLongBetween(0, 5))
+            ->assert(42);
     }
 
     /** @covers ::assert() */
@@ -66,7 +76,8 @@ final class IsLongBetweenTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long between 0 and 1. Got 2.');
 
-        (new IsLongBetween(0, 1, 'UTF-8'))->assert('ππ');
+        (new IsLongBetween(0, 1, 'UTF-8'))
+            ->assert('ππ');
     }
 
     /** @covers ::assert() */

--- a/tests/Assertion/String/IsLongTest.php
+++ b/tests/Assertion/String/IsLongTest.php
@@ -28,7 +28,6 @@ final class IsLongTest extends TestCase
 
         (new IsLong(11))
             ->assert('Hello World');
-
     }
 
     /**

--- a/tests/Assertion/String/IsLongTest.php
+++ b/tests/Assertion/String/IsLongTest.php
@@ -24,11 +24,25 @@ final class IsLongTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsLong(11))
+            ->assert('Hello World');
+
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long 6. Got 5.');
 
-        (new IsLong(11))->assert('Hello World');
-        (new IsLong(6))->assert('Hello');
+        (new IsLong(6))
+            ->assert('Hello');
     }
 
     /**
@@ -41,7 +55,8 @@ final class IsLongTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('"Foo" is not a valid system encoding.');
 
-        (new IsLong(11, 'Foo'))->assert('foo');
+        (new IsLong(11, 'Foo'))
+            ->assert('foo');
     }
 
     /** @covers ::assert() */
@@ -50,13 +65,8 @@ final class IsLongTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new IsLong(3))->assert(42);
+        (new IsLong(3))
+            ->assert(42);
     }
 
     /** @covers ::assert() */
@@ -65,6 +75,7 @@ final class IsLongTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected string to be long 2. Got 1.');
 
-        (new IsLong(2, 'UTF-8'))->assert('π');
+        (new IsLong(2, 'UTF-8'))
+            ->assert('π');
     }
 }

--- a/tests/Assertion/String/StartsWithTest.php
+++ b/tests/Assertion/String/StartsWithTest.php
@@ -24,11 +24,23 @@ final class StartsWithTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new StartsWith('Hello'))->assert('Hello World');
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected that string "Hello World" starts with "World".');
 
-        (new StartsWith('Hello'))->assert('Hello World');
-        (new StartsWith('World'))->assert('Hello World');
+        (new StartsWith('World'))
+            ->assert('Hello World');
     }
 
     /** @covers ::assert() */
@@ -37,12 +49,7 @@ final class StartsWithTest extends TestCase
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        /**
-         * This is covered by static analysis but it is a valid runtime call
-         *
-         * @psalm-suppress InvalidScalarArgument
-         * @phpstan-ignore-next-line
-         */
-        (new StartsWith('H'))->assert(42);
+        (new StartsWith('H'))
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Type/IsArrayTest.php
+++ b/tests/Assertion/Type/IsArrayTest.php
@@ -23,10 +23,22 @@ final class IsArrayTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsArray())
+            ->assert([1, 2, 3]);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException (): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be array. Got integer.');
 
-        (new IsArray())->assert([1, 2, 3]);
-        (new IsArray())->assert(42);
+        (new IsArray())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Type/IsArrayTest.php
+++ b/tests/Assertion/Type/IsArrayTest.php
@@ -33,7 +33,7 @@ final class IsArrayTest extends TestCase
      * @covers ::assert()
      * @covers ::__invoke()
      */
-    public function testAssertException (): void
+    public function testAssertException(): void
     {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be array. Got integer.');

--- a/tests/Assertion/Type/IsBooleanTest.php
+++ b/tests/Assertion/Type/IsBooleanTest.php
@@ -23,10 +23,22 @@ final class IsBooleanTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsBoolean())
+            ->assert(true);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be boolean. Got integer.');
 
-        (new IsBoolean())->assert(true);
-        (new IsBoolean())->assert(42);
+        (new IsBoolean())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Type/IsCallableTest.php
+++ b/tests/Assertion/Type/IsCallableTest.php
@@ -24,10 +24,22 @@ final class IsCallableTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsCallable())
+            ->assert(new IsInteger());
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be callable. Got integer.');
 
-        (new IsCallable())->assert(new IsInteger());
-        (new IsCallable())->assert(42);
+        (new IsCallable())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Type/IsFloatTest.php
+++ b/tests/Assertion/Type/IsFloatTest.php
@@ -23,10 +23,22 @@ final class IsFloatTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsFloat())
+            ->assert(4.5);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be float. Got string.');
 
-        (new IsFloat())->assert(4.5);
-        (new IsFloat())->assert('Hello World');
+        (new IsFloat())
+            ->assert('Hello World');
     }
 }

--- a/tests/Assertion/Type/IsIntegerTest.php
+++ b/tests/Assertion/Type/IsIntegerTest.php
@@ -23,10 +23,22 @@ final class IsIntegerTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsInteger())
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be an integer. Got string.');
 
-        (new IsInteger())->assert(42);
-        (new IsInteger())->assert('Hello World');
+        (new IsInteger())
+            ->assert('Hello World');
     }
 }

--- a/tests/Assertion/Type/IsNumericTest.php
+++ b/tests/Assertion/Type/IsNumericTest.php
@@ -24,11 +24,25 @@ final class IsNumericTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+        
+        (new IsNumeric())(3.14);
+
+        (new IsNumeric())
+            ->assert(42);
+    }
+
+    /**
+     * @covers ::__construct()
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be either integer or float. Got "42".');
 
-        (new IsNumeric())(3.14);
-        (new IsNumeric())->assert(42);
-        (new IsNumeric())->assert('42');
+        (new IsNumeric())
+            ->assert('42');
     }
 }

--- a/tests/Assertion/Type/IsNumericTest.php
+++ b/tests/Assertion/Type/IsNumericTest.php
@@ -25,7 +25,7 @@ final class IsNumericTest extends TestCase
     public function testAssert(): void
     {
         static::expectNotToPerformAssertions();
-        
+
         (new IsNumeric())(3.14);
 
         (new IsNumeric())

--- a/tests/Assertion/Type/IsObjectTest.php
+++ b/tests/Assertion/Type/IsObjectTest.php
@@ -24,10 +24,22 @@ final class IsObjectTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsObject())
+            ->assert(new stdClass());
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be object. Got integer.');
 
-        (new IsObject())->assert(new stdClass());
-        (new IsObject())->assert(42);
+        (new IsObject())
+            ->assert(42);
     }
 }

--- a/tests/Assertion/Type/IsStringTest.php
+++ b/tests/Assertion/Type/IsStringTest.php
@@ -23,10 +23,22 @@ final class IsStringTest extends TestCase
      */
     public function testAssert(): void
     {
+        static::expectNotToPerformAssertions();
+
+        (new IsString())
+            ->assert('Hello World');
+    }
+
+    /**
+     * @covers ::assert()
+     * @covers ::__invoke()
+     */
+    public function testAssertException(): void
+    {
         static::expectException(AssertionFailed::class);
         static::expectExceptionMessage('Expected value to be string. Got integer.');
 
-        (new IsString())->assert('Hello World');
-        (new IsString())->assert(42);
+        (new IsString())
+            ->assert(42);
     }
 }


### PR DESCRIPTION
This pull request refactors all the Assertion module template parameters.

Class Each.php now take a single assertion argument, it can be used with All.php to perform multiple checks.
Class Either.php now take two arguments.

Prior of the introduction of expectNotToPerformAssertions() a single test performed both success and failure.
Now the success part is extracted in a method on its own.

